### PR TITLE
Fix for "Uncaught ReferenceError: Deps is not defined"

### DIFF
--- a/package.js
+++ b/package.js
@@ -3,6 +3,7 @@ Package.describe({
 });
 
 Package.on_use(function (api) {
+  api.use('standard-app-packages');
   api.use(['underscore', 'deps', 'session', 'handlebars'], 'client');
 
   api.add_files(['device_detection.js', 'device_helpers.js'], 'client');


### PR DESCRIPTION
Reference to 'standard-app-packages' fixes 'Deps is not defined' error.  Enjoy!
