### PR TITLE
Corrected homepage and git URLs

### DIFF
--- a/smart.json
+++ b/smart.json
@@ -1,8 +1,8 @@
 {
   "name": "device-detection",
   "description": "Client-Side Device Type Detection & Template Switching with Optional Meteor-Router Support",
-  "homepage": "https://github.com/Mystor/meteor-device-detection/",
+  "homepage": "https://github.com/mystor/meteor-device-detection",
   "author": "Michael Layzell",
   "version": "0.1.4",
-  "git": "https://github.com/Mystor/meteor-device-detection.git"
+  "git": "https://github.com/mystor/meteor-device-detection.git"
 }


### PR DESCRIPTION
I was unable to retrieve the package via meteorite. Github URLs are
case-sensitive and the author's user name was incorrectly capitalised.
Correcting the case fixed the problem.

Also, I removed the unnecessary trailing slash from the homepage URL.
