### PR TITLE
Fix use of deprecated API in package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,15 +1,15 @@
 Package.describe({
   name: "mystor:device-detection",
   summary: "Client-Side Device Type Detection & Template Switching with Optional Meteor-Router Support",
-  version: "0.2.0",
+  version: "0.3.0",
   git: "https://github.com/mystor/meteor-device-detection.git"
 });
 
-Package.on_use(function (api) {
-  api.versionsFrom('METEOR@0.9.0');
+Package.onUse(function (api) {
+  api.versionsFrom('METEOR@1.0.0');
 
   api.use(['meteor', 'underscore', 'deps', 'session', 'templating', 'ui'], 'client');
 
-  api.add_files(['device_detection.js', 'device_helpers.js'], 'client');
+  api.addFiles(['device_detection.js', 'device_helpers.js'], 'client');
 });
 


### PR DESCRIPTION
Fixes use of deprecated API in `package.js` which has been finally removed in Meteor 2.3